### PR TITLE
Fix crate name for aelred

### DIFF
--- a/data/repositories.json
+++ b/data/repositories.json
@@ -842,7 +842,7 @@
   {
     "owner": "aelred",
     "name": "aoc2024",
-    "crate": "aoc2024",
+    "crate": null,
     "toolchain": "stable"
   },
   {


### PR DESCRIPTION
It's at the top level of the repo, so it shouldn't have `crate` set: https://github.com/aelred/aoc2024

Sorry, I misunderstood this field so I missed the day 5 run 😅